### PR TITLE
Add check for plans on output, fixes #8

### DIFF
--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -48,6 +48,11 @@ module.exports = function () {
       dup.failed = true
     }
 
+    if (res.plans.length < 1) {
+      dup.failed = true
+      process.exit(1)
+    }
+
     dup.emit('summary', {
       duration: duration,
       assertions: res.asserts.length,
@@ -78,4 +83,3 @@ function getTest(n, tests) {
   }
   return null
 }
-


### PR DESCRIPTION
tap-out emits and tracks the plans line.  According to the TAP spec the plans line must appear once.  If plans array is empty then output did not finish.  tap-summary should then exit with error code.
