### PR TITLE
Fixed bug with multiple var declaration and assignment in reporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -77,7 +77,8 @@ module.exports = function () {
       stats.planned.raw = planned
     }
 
-    var fails = comments = null
+    var fails = null
+    var comments = null
     if (stats.fail) {
       fails = res.fail.reduce(function (o, assertion) {
         var name = getTest(assertion.test, res.tests).name


### PR DESCRIPTION
In strict mode code like this:

var foo = bar = null;

will cause error: 'bar' is not defined.

Latest version of webpack injects 'use strict' automaticaly in some files causing code to break when using such coding practice.